### PR TITLE
escape urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 Gemfile.lock
 *~
 pkg/*
+tmp/

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--format documentation

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,8 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+guard :rspec do
+  watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^spec/spec_helper\.rb$}) { "spec" }
+end
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # xing
+
 Ruby wrapper for the [Xing API](https://dev.xing.com).
 
+## Supported Rubies
+
+Currently, only Ruby 2.0 is supported.
+
 ## Installation
+
     [sudo] gem install xing
 
 ## Usage

--- a/lib/xing/helpers/request.rb
+++ b/lib/xing/helpers/request.rb
@@ -4,41 +4,46 @@ module Xing
   module Helpers
     module Request
 
-      API_PATH = '/v1'
+      API_PATH        = '/v1'
       DEFAULT_HEADERS = {}
 
       protected
 
-        def get(path, options={})
-          response = access_token.get("#{API_PATH}#{path}", DEFAULT_HEADERS.merge(options))
-          respond response
-        end
+      def escape path
+        CGI::escape path
+      end
 
-        def post(path, body='', options={})
-          response = access_token.post("#{API_PATH}#{path}", body, DEFAULT_HEADERS.merge(options))
-          respond response
-        end
 
-        def put(path, body, options={})
-          response = access_token.put("#{API_PATH}#{path}", body, DEFAULT_HEADERS.merge(options))
-          respond response
-        end
+      def get(path, options={})
+        response = access_token.get("#{API_PATH}#{escape path}", DEFAULT_HEADERS.merge(options))
+        respond response
+      end
 
-        def delete(path, options={})
-          response = access_token.delete("#{API_PATH}#{path}", DEFAULT_HEADERS.merge(options))
-          respond response
-        end
+      def post(path, body='', options={})
+        response = access_token.post("#{API_PATH}#{escape path}", body, DEFAULT_HEADERS.merge(options))
+        respond response
+      end
+
+      def put(path, body, options={})
+        response = access_token.put("#{API_PATH}#{escape path}", body, DEFAULT_HEADERS.merge(options))
+        respond response
+      end
+
+      def delete(path, options={})
+        response = access_token.delete("#{API_PATH}#{escape path}", DEFAULT_HEADERS.merge(options))
+        respond response
+      end
 
       private
 
-        def respond response
-          raise_errors response
-          MultiJson.load(response.body)
-        end
+      def respond response
+        raise_errors response
+        MultiJson.load(response.body)
+      end
 
-        def raise_errors(response)
+      def raise_errors(response)
 
-          case response.code.to_i
+        case response.code.to_i
           when 401
             data = Mash.from_json(response.body)
             ap data
@@ -52,24 +57,24 @@ module Xing
             raise Xing::Errors::ServerError, "(#{response.code}): #{response.message}"
           when 502..503
             raise Xing::Errors::UnavailableError, "(#{response.code}): #{response.message}"
-          end
         end
+      end
 
-        def to_query(options)
-          options.inject([]) do |collection, opt|
-            collection << "#{opt[0]}=#{opt[1]}"
-            collection
-          end * '&'
+      def to_query(options)
+        options.inject([]) do |collection, opt|
+          collection << "#{opt[0]}=#{opt[1]}"
+          collection
+        end * '&'
+      end
+
+      def to_uri(path, options)
+        uri = URI.parse(path)
+
+        if options && options != {}
+          uri.query = to_query(options)
         end
-
-        def to_uri(path, options)
-          uri = URI.parse(path)
-
-          if options && options != {}
-            uri.query = to_query(options)
-          end
-          uri.to_s
-        end
+        uri.to_s
+      end
 
     end
   end

--- a/spec/cases/client_spec.rb
+++ b/spec/cases/client_spec.rb
@@ -29,9 +29,9 @@ describe Xing::Client do
 
   describe "#contacts" do
     before do
-      stub_request(:get, "https://api.xing.com/v1/users/me/contacts?limit=3&offset=0").
+      stub_request(:get, "https://api.xing.com/v1%2Fusers%2Fme%2Fcontacts%3Foffset=3&limit=3").
           to_return(:status => 200, :body => fixture("contacts_page_1.json"), :headers => {})
-      stub_request(:get, "https://api.xing.com/v1/users/me/contacts?limit=3&offset=3").
+      stub_request(:get, "https://api.xing.com/v1%2Fusers%2Fme%2Fcontacts%3Foffset=0&limit=3").
           to_return(:status => 200, :body => fixture("contacts_page_2.json"), :headers => {})
     end
 
@@ -46,11 +46,11 @@ describe Xing::Client do
   end
 
   describe '#create_conversation' do
-    let(:conversation_hash) { {content: 'msg', recipient_ids: [1, 2], subject: 'subject'} }
+    let(:conversation_hash) { {content: 'msg', recipient_ids: [1, 2], subject: 'subject with special chars!'} }
     subject { client.create_conversation conversation_hash }
 
     before do
-      stub_request(:post, "https://api.xing.com/v1/users/me/conversations?content=msg&recipient_ids=1,2&subject=subject").
+      stub_request(:post, "https://api.xing.com/v1%2Fusers%2Fme%2Fconversations%3Fcontent=msg&recipient_ids=1,2&subject=subject+with+special+chars!").
           to_return(:status => 200, :body => fixture("create_conversation_result.json"), :headers => {})
     end
 

--- a/xing.gemspec
+++ b/xing.gemspec
@@ -26,5 +26,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rdoc', '~> 3.8'
   gem.add_development_dependency 'rspec', '~> 2.6'
   gem.add_development_dependency 'webmock', '~> 1.8.7'
+  gem.add_development_dependency 'guard-rspec', '~> 3.0.0'
 
 end


### PR DESCRIPTION
Hi,

I added Guard and rspec formating, but mainly, this pull request is about the escaping of url. The problem occured while using conversations with special character's in the subject.

If you let the conversation_hash under `describe '#create_conversation'` have a more complex subject, you can reproduce the problem.

Cheers,
Robin
