### PR TITLE
Fix 1.9 compatibility (for mri and jruby)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ruby wrapper for the [Xing API](https://dev.xing.com).
 
 ## Supported Rubies
 
-Currently, only Ruby 2.0 is supported.
+Currently, only Ruby 2.0 is supported, 1.9.3 does pass the tests.
 
 ## Installation
 

--- a/lib/xing/api/writer.rb
+++ b/lib/xing/api/writer.rb
@@ -3,7 +3,7 @@ module Xing
     module Writer
       # @return [Hashie::Mash] with the return value from xing.
       # see https://dev.xing.com/docs/post/users/:user_id/conversations or create_conversation_result.json
-      def create_conversation **args
+      def create_conversation(args = {})
         raise ArgumentError.new("subject must be a String") unless args[:subject].is_a?(String)
         raise ArgumentError.new("recipient_ids must be a non-empty Array") unless args[:recipient_ids].is_a?(Array) and not args[:recipient_ids].empty?
         raise ArgumentError.new("content must be a non-empty String") unless args[:content].is_a?(String) and not args[:content].empty?

--- a/xing.gemspec
+++ b/xing.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  gem.add_dependency 'hashie', '~> 1.2.0'
+  gem.add_dependency 'hashie', '> 1.2'
   gem.add_dependency 'multi_json', '>= 1.3.6'
   gem.add_dependency 'oauth', '~> 0.4.5'
   

--- a/xing.gemspec
+++ b/xing.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  gem.add_dependency 'hashie', '~> 2.0.0'
+  gem.add_dependency 'hashie', '~> 1.2.0'
   gem.add_dependency 'multi_json', '>= 1.3.6'
   gem.add_dependency 'oauth', '~> 0.4.5'
   


### PR DESCRIPTION
JRuby currently does not support the full 2.0 syntax. I have updated the 1 place where 2.0 only code was used to use the older 1.9 compatible syntax. Please consider pulling.
