### PR TITLE
Adds support for contact requests

### DIFF
--- a/lib/xing/api/writer.rb
+++ b/lib/xing/api/writer.rb
@@ -17,6 +17,49 @@ module Xing
         Xing::Mash.new(post("#{path}?#{args}")['conversation'])
       end
 
+      # @return true
+      # see https://dev.xing.com/docs/get/users/:user_id/contact_requests
+      def create_contact_request(args = {})
+        user_id = args.delete :user_id
+
+        raise ArgumentError.new("user_id must be a String") unless user_id.is_a?(String)
+        raise ArgumentError.new("message must be a String") if args[:message] && !args[:message].is_a?(String)
+
+        path = "/users/%s/contact_requests" % user_id
+
+        args = args.to_a.map{|e| "#{e[0]}=#{e[1]}"}.join("&")
+
+        post("#{path}?#{args}")
+        true
+      end
+
+      # @return true
+      def accept_contact_request(args = {})
+        user_id = args.delete :user_id
+
+        raise ArgumentError.new("user_id must be a String") unless user_id.is_a?(String)
+
+        my_id = profile['users'].first['id']
+
+        path = '/users/%s/contact_requests/%s/accept' % [my_id, user_id]
+
+        put(path, '')
+        true
+      end
+
+      # @return true
+      def deny_contact_request(args = {})
+        user_id = args.delete :user_id
+
+        raise ArgumentError.new("user_id must be a String") unless user_id.is_a?(String)
+
+        my_id = profile['users'].first['id']
+
+        path = '/users/%s/contact_requests/%s' % [my_id, user_id]
+
+        delete(path)
+        true
+      end
 
       # @return [Hashie::Mash] with the response :code and :body from xing
       # see https://dev.xing.com/docs/post/users/:id/status_message


### PR DESCRIPTION
Title says it all :) One can now add, accept and deny contact quests with:

``` ruby
# Sending a contact request
# :message is optional
client.create_contact_request(:user_id => "Your_Id", :message => "Hey, become my newest contact!")

# Accepting a contact request
client.accept_contact_request(:user_id => "Some_User_Who_Sent_You_A_Request")

# Deny a contact request
client.accept_contact_request(:user_id => "Some_User_Who_Sent_You_A_Request")
```
